### PR TITLE
nginx: redirect more image types

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -17,11 +17,9 @@ server {
     proxy_ssl_server_name on;
 
     # This is the ART S3 bucket.
-    # For metadata (JSON) we proxy rather
-    # than redirect, to help avoid the URI leaking. However, for the
-    # qcow2 (and in the future other images) we do a HTTP redirect, to avoid
-    # serving significant traffic from the redirector.
-    rewrite ^/art/storage/(.*\.qcow2.*) https://art-rhcos-ci.s3.amazonaws.com/$1 redirect;
+    # Redirect most of the image artifacts to the S3 bucket; the other requests
+    # are proxied to the bucket.
+    rewrite ^/art/storage/(.*\.img.*|.*\.iso.*|.*\.ova.*|.*\.qcow2.*|.*\.raw.*|.*\.tar.*|.*\.vhd.*|.*\.vmdk.*) https://art-rhcos-ci.s3.amazonaws.com/$1 redirect;
     location /art/storage {
          rewrite    /art/storage/(.*) /$1 break;
          proxy_pass https://art-rhcos-ci.s3.amazonaws.com;


### PR DESCRIPTION
We were only redirecting URLs (HTTP 302 response) for qcow2
artifacts, but we have a lot more than just those these days.

Update the rewrite config to redirect almost all the artifacts to the
S3 server, rather than proxying the request.